### PR TITLE
DFTDP-114 fix dockerfile by reverting version tag to last working release

### DIFF
--- a/driver-portal/src/ClientApp/Dockerfile
+++ b/driver-portal/src/ClientApp/Dockerfile
@@ -1,4 +1,5 @@
-FROM trion/ng-cli-karma AS ng-builder
+# version 17.1.0 introduced breaking changes to RUN npm install, try change 17.0.10 tag to latest on subsequent versions
+FROM trion/ng-cli-karma:17.0.10 AS ng-builder
 
 COPY ./package*.json ./
 COPY ./shared-portal-ui/ ./shared-portal-ui
@@ -6,7 +7,7 @@ COPY ./driver-portal/src/ClientApp ./driver-portal/src/ClientApp
 
 WORKDIR /app/driver-portal/src/ClientApp
 
-RUN npm install
+RUN npm install 
 
 #RUN npm run lint
 #RUN npm run test -- --no-watch --no-progress

--- a/driver-portal/src/Program.cs
+++ b/driver-portal/src/Program.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
-using Pssg.DocumentStorageAdapter.Helpers;
 using Rsbc.Dmf.DriverPortal.Api;
 using Rsbc.Dmf.DriverPortal.Api.Services;
 using System.Net;

--- a/driver-portal/src/README.md
+++ b/driver-portal/src/README.md
@@ -27,7 +27,7 @@ change directory to the repository root folder 'rsbc-dmf'
 `docker build . --file ./driver-portal/src/ClientApp/Dockerfile --tag driver-portal-ui`
 
 # to debug docker
-```
+```bash
 docker run -rm --name driver-portal-api driver-portal-api
 # add tail -f entrypoint to docker otherwise it will not stay running
 # useful if you want to look at folder structure

--- a/driver-portal/src/README.md
+++ b/driver-portal/src/README.md
@@ -3,7 +3,11 @@
 ## Run
 
 To start the app on port 3020, which OAuth has a redirect uri entry for, and to run with ssl certificate, use the following:
-npm start
+`npm start`
+
+## Test
+
+`ng t`
 
 ## Development Environment
 
@@ -14,17 +18,19 @@ The Driver Portal application has the following requirements:
 
 ## Docker Build
 
-cd rsbc-dmf
+change directory to the repository root folder 'rsbc-dmf'
 
-# build driver-portal-api backend
-docker build --tag driver-portal-api --build-arg BUILD_ID --build-arg BUILD_VERSION="1.0.2.40" . --file ./driver-portal/src/Dockerfile
+# build driver-portal-api
+`docker build --tag driver-portal-api --build-arg BUILD_ID --build-arg BUILD_VERSION="1.0.2.40" . --file ./driver-portal/src/Dockerfile`
 
-# build driver-portal-api frontend
-docker build . --file ./driver-portal/src/ClientApp/Dockerfile --tag driver-portal-api
+# build driver-portal-ui
+`docker build . --file ./driver-portal/src/ClientApp/Dockerfile --tag driver-portal-ui`
 
-# to debug docker make sure you add tail -f entrypoint
+# to debug docker
+```
 docker run -rm --name driver-portal-api driver-portal-api
+# add tail -f entrypoint to docker otherwise it will not stay running
+# useful if you want to look at folder structure
 docker exec -it driver-portal-api bash
 docker stop driver-portal-api
-docker rm driver-portal-api
-docker image rm driver-portal-api
+```


### PR DESCRIPTION
there is a breaking change in trion/ng-cli-karma:17.1.0, so I used a previous version. If we want to change it back to the latest tag, we can revisit it on subsequent version releases on docker hub