### PR TITLE
DFTDP-115 driver authorization

### DIFF
--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
@@ -186,15 +186,11 @@ message GetDocumentsReply {
 	string errorDetail = 3;
 }
 
-
 message GetCommentReply {
 	LegacyComment item = 1;
 	ResultStatus resultStatus = 2;
 	string errorDetail = 3;
 }
-
-
-
 
 message LegacyComment {
 	int64 SequenceNumber = 1;
@@ -257,8 +253,6 @@ message PdfDocumentReply {
 
 message PdfDocument{
   string pdfDocumentId = 1;
-
-  
   enum StatusCodeOptions{
 	  SendToBCMail = 0;
 	  Sent = 1;
@@ -267,7 +261,6 @@ message PdfDocument{
   StatusCodeOptions statusCode = 2;
   string filename = 3;
   string serverUrl = 4;
-  
 }
 
 message CaseDetail {
@@ -289,7 +282,6 @@ message CaseDetail {
 	int64 outstandingDocuments = 16;
 	string eligibleLicenseClass = 17;
 }
-
 
 message CreateStatusReply {	
 	ResultStatus resultStatus = 1;
@@ -323,7 +315,6 @@ message ManualPassRequest{
 	string caseId = 1;
 }
 
-
 message GetAllFlagsReply {
 	repeated FlagItem Flags = 1;
 }
@@ -344,7 +335,6 @@ message DmerCase {
 	repeated FlagItem Flags = 30;
 	repeated DecisionItem Decisions = 35;
 	int64 caseSequence = 40;
-
 }
 
 message Driver {
@@ -417,7 +407,6 @@ message CreateCaseRequest {
 	string SubmittalStatus = 6;
 }
 
-
 message UpdateCaseRequest{
 	string caseId = 1;
 	bool isCleanPass = 2;
@@ -444,14 +433,12 @@ message SetCasePractitionerClinicReply{
 	string errorDetail = 2;
 }
 
-
 message LegacyCandidateRequest{
 	string licenseNumber = 1;
     string clientNumber = 2;
 	string surname = 3;
 	google.protobuf.Timestamp birthDate = 4;
 	google.protobuf.Timestamp effectiveDate = 5;
-
 }
 
 message LegacyCandidateReply{
@@ -459,8 +446,6 @@ message LegacyCandidateReply{
 	string errorDetail = 2;
 	bool isNewCase = 3;
 }
-
-
 
 message FlagItem {
 	string identifier = 1;
@@ -502,11 +487,20 @@ message CssReply {
 	string css = 3; 
 }
 
-
 service UserManager {
   rpc Search (UsersSearchRequest) returns (UsersSearchReply);
   rpc Login (UserLoginRequest) returns (UserLoginReply);
   rpc SetEmail(UserSetEmailRequest) returns (ResultStatusReply);
+  rpc IsDriverAuthorized(UserDriverAuthorizedRequest) returns (ResultBoolReply);
+}
+
+message ResultBoolReply {
+	bool result = 1;
+}
+
+message UserDriverAuthorizedRequest {
+	string userId = 1;
+	string driverId = 2;
 }
 
 message UserSetEmailRequest {

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/UserService.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/UserService.cs
@@ -15,6 +15,13 @@ namespace Rsbc.Dmf.CaseManagement.Service
             this.userManager = userManager;
         }
 
+        public async override Task<ResultBoolReply> IsDriverAuthorized(UserDriverAuthorizedRequest request, ServerCallContext context) 
+        {
+            var driverId = Guid.Parse(request.DriverId);
+            var result = userManager.IsDriverAuthorized(request.UserId, driverId);
+            return new ResultBoolReply() { Result = result };
+        }
+
         public async override Task<UsersSearchReply> Search(UsersSearchRequest request, ServerCallContext context)
         {
             try

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/UserManager.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/UserManager.cs
@@ -16,6 +16,8 @@ namespace Rsbc.Dmf.CaseManagement
         Task<LoginUserResponse> LoginUser(LoginUserRequest request);
 
         Task<bool> SetUserEmail(string userId, string email);
+
+        bool IsDriverAuthorized(string userId, Guid driverId);
     }
 
     public class SearchUsersRequest
@@ -85,6 +87,18 @@ namespace Rsbc.Dmf.CaseManagement
         public UserManager(DynamicsContext dynamicsContext)
         {
             this.dynamicsContext = dynamicsContext;
+        }
+
+        public bool IsDriverAuthorized(string userId, Guid driverId)
+        {
+            var loggedInDriver = dynamicsContext.dfp_logins
+                .Expand(l => l.dfp_DriverId)
+                .Where(l => l.dfp_userid == userId && l.statecode == (int)EntityState.Active)
+                .Where(d => d._dfp_driverid_value == driverId && d.dfp_DriverId.statecode == (int)EntityState.Active)
+                .ToList()
+                .SingleOrDefault();
+
+            return loggedInDriver != default;
         }
 
         public async Task<SearchUsersResponse> SearchUsers(SearchUsersRequest request)

--- a/driver-portal/src/Controllers/CasesController.cs
+++ b/driver-portal/src/Controllers/CasesController.cs
@@ -62,6 +62,7 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
         /// <param name="driverId">The driver id</param>
         /// <returns></returns>
         [HttpGet("{driverId}/Closed")]
+        [AuthorizeDriver(ParameterName = "driverId")]
         [ProducesResponseType(typeof(IEnumerable<CaseDetail>), 200)]
         [ProducesResponseType(401)]
         [ProducesResponseType(500)]

--- a/driver-portal/src/Controllers/DriverController.cs
+++ b/driver-portal/src/Controllers/DriverController.cs
@@ -29,7 +29,7 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
         /// <param name="driverId">The driver id</param>
         /// <returns>CaseDocuments</returns>
         [HttpGet("{driverId}/Documents")]
-        [AuthorizeDriver]
+        [AuthorizeDriver(ParameterName = "driverId")]
         [ProducesResponseType(typeof(CaseDocuments), 200)]
         [ProducesResponseType(401)]
         [ProducesResponseType(500)]
@@ -103,7 +103,7 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
         /// <param name="driverId">The driver id</param>
         /// <returns>CaseDocuments</returns>
         [HttpGet("{driverId}/AllDocuments")]
-        [AuthorizeDriver]
+        [AuthorizeDriver(ParameterName = "driverId")]
         [ProducesResponseType(typeof(IEnumerable<Document>), 200)]
         [ProducesResponseType(401)]
         [ProducesResponseType(500)]

--- a/driver-portal/src/Controllers/DriverController.cs
+++ b/driver-portal/src/Controllers/DriverController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Rsbc.Dmf.CaseManagement.Service;
+using Rsbc.Dmf.DriverPortal.Api.Services;
 using Rsbc.Dmf.DriverPortal.ViewModels;
 
 namespace Rsbc.Dmf.DriverPortal.Api.Controllers
@@ -28,7 +29,7 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
         /// <param name="driverId">The driver id</param>
         /// <returns>CaseDocuments</returns>
         [HttpGet("{driverId}/Documents")]
-        [AllowAnonymous]
+        [AuthorizeDriver]
         [ProducesResponseType(typeof(CaseDocuments), 200)]
         [ProducesResponseType(401)]
         [ProducesResponseType(500)]
@@ -96,14 +97,13 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
             }
         }
 
-
         /// <summary>
         /// Get all documents for a given driver but filter out documents without a url
         /// </summary>
         /// <param name="driverId">The driver id</param>
         /// <returns>CaseDocuments</returns>
         [HttpGet("{driverId}/AllDocuments")]
-        [AllowAnonymous]
+        [AuthorizeDriver]
         [ProducesResponseType(typeof(IEnumerable<Document>), 200)]
         [ProducesResponseType(401)]
         [ProducesResponseType(500)]

--- a/driver-portal/src/Model/Attribute/AuthorizeDriverAttribute.cs
+++ b/driver-portal/src/Model/Attribute/AuthorizeDriverAttribute.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Rsbc.Dmf.DriverPortal.Api.Services;
+
+namespace Rsbc.Dmf.DriverPortal.Api
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class AuthorizeDriverAttribute : Attribute, IFilterFactory
+    {
+        public bool IsReusable => false;
+
+        public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+        {
+            return serviceProvider.GetService<AuthorizeDriver>();
+        }
+
+        public class AuthorizeDriver : ActionFilterAttribute, IAsyncAuthorizationFilter
+        {
+            private readonly IUserService _userService;
+
+            public AuthorizeDriver(IUserService userService)
+            {
+                _userService = userService;
+            }
+
+            public async Task OnAuthorizationAsync(AuthorizationFilterContext filterContext)
+            {
+                if (!filterContext.RouteData.Values.ContainsKey("driverId"))
+                {
+                    filterContext.Result = new BadRequestObjectResult("parameter driverId missing.");
+                    return;
+                }
+
+                var driverId = filterContext.RouteData.Values["driverId"] as string;
+
+                var isAuthorizedResponse = await _userService.IsDriverAuthorized(driverId);
+                if (!isAuthorizedResponse)
+                    filterContext.Result = new UnauthorizedResult();
+            }
+        }
+    }
+}

--- a/driver-portal/src/Services/UserService.cs
+++ b/driver-portal/src/Services/UserService.cs
@@ -14,12 +14,10 @@ namespace Rsbc.Dmf.DriverPortal.Api.Services
     public interface IUserService
     {
         Task<UserContext> GetCurrentUserContext();
-
         Task<UserContext> GetUserContext(ClaimsPrincipal user);
-
         Task<ClaimsPrincipal> Login(ClaimsPrincipal user);
-
         Task SetEmail(string userId, string email);
+        Task<bool> IsDriverAuthorized(string driverId);
     }
 
     public record UserContext
@@ -59,6 +57,16 @@ namespace Rsbc.Dmf.DriverPortal.Api.Services
                 LastName = user.FindFirstValue(ClaimTypes.Surname),
                 Email = user.FindFirstValue(ClaimTypes.Email)
             });
+        }
+
+        public async Task<bool> IsDriverAuthorized(string driverId)
+        {
+            var request = new UserDriverAuthorizedRequest();
+            request.UserId = (await GetCurrentUserContext()).Id;
+            request.DriverId = driverId;
+
+            var isAuthorizedResponse = userManager.IsDriverAuthorized(request);
+            return isAuthorizedResponse.Result;
         }
 
         public async Task<ClaimsPrincipal> Login(ClaimsPrincipal user)

--- a/driver-portal/src/Tests/ApiIntegrationTestBase.cs
+++ b/driver-portal/src/Tests/ApiIntegrationTestBase.cs
@@ -8,15 +8,15 @@ namespace Rsbc.Dmf.DriverPortal.Tests
 {
     public abstract class ApiIntegrationTestBase : IDisposable
     {
-        protected HttpClient _client { get; }
-        protected IConfiguration _configuration { get; }
+        protected readonly HttpClient _client;
+        protected readonly IConfiguration _configuration;
         protected const string CASE_API_BASE = "/api/Cases";
         protected const string DRIVER_API_BASE = "/api/Driver";
 
-        public ApiIntegrationTestBase(IConfiguration configuration)
+        public ApiIntegrationTestBase(IConfiguration configuration, bool enableAuthorization = false)
         {
             _configuration = configuration;
-            _client = new CustomWebApplicationFactory(configuration)
+            _client = new CustomWebApplicationFactory(configuration, enableAuthorization)
                 .CreateClient();
         }
 

--- a/driver-portal/src/Tests/CustomWebApplicationFactory.cs
+++ b/driver-portal/src/Tests/CustomWebApplicationFactory.cs
@@ -1,11 +1,20 @@
 ﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Rsbc.Dmf.CaseManagement.Helpers;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Pssg.DocumentStorageAdapter.Helpers;
+using Rsbc.Dmf.CaseManagement.Helpers;
 using Rsbc.Dmf.DriverPortal.Api;
+using Rsbc.Dmf.DriverPortal.Api.Services;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+using static Rsbc.Dmf.DriverPortal.Api.AuthorizeDriverAttribute;
 
 namespace Rsbc.Dmf.DriverPortal.Tests
 {
@@ -15,17 +24,57 @@ namespace Rsbc.Dmf.DriverPortal.Tests
     public class CustomWebApplicationFactory : WebApplicationFactory<Program>
     {
         private readonly IConfiguration _configuration;
+        private readonly bool _isAuthorizationEnabled;
 
-        public CustomWebApplicationFactory(IConfiguration configuration)
+        public CustomWebApplicationFactory(IConfiguration configuration, bool isAuthorizationEnabled)
         {
             _configuration = configuration;
+            _isAuthorizationEnabled = isAuthorizationEnabled;
         }
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {           
-            // document storage client
+        {
             builder.ConfigureTestServices(services =>
             {
+                services.AddControllersWithViews().AddJsonOptions(x =>
+                {
+                    x.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    x.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+                });
+
+                services.AddAutoMapperSingleton(LoggerFactory.Create(loggingBuilder => loggingBuilder.AddConsole()));
+
+                // setup http context with mocked user claims
+                var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+                var context = new DefaultHttpContext();
+                var user = new ClaimsPrincipal();
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.Sid, "QPSETRIJEOMSARHBRNRPBVAIFL65V3YI"),
+                    new Claim(ClaimTypes.Email, "Email"),
+                    new Claim(ClaimTypes.Upn, $"ExternalSystemUserId"),
+                    new Claim(ClaimTypes.GivenName, "FirstName"),
+                    new Claim(ClaimTypes.Surname, "LastName")
+                };
+                user.AddIdentity(new ClaimsIdentity(claims));
+                context.User = user;
+                mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(context);
+                services.AddTransient(x => mockHttpContextAccessor.Object);
+
+                if (!_isAuthorizationEnabled)
+                {
+                    var userService = new Mock<IUserService>();
+                    userService.Setup(x => x.IsDriverAuthorized(It.IsAny<string>())).ReturnsAsync(true);
+                    services.AddTransient(x => userService.Object);
+                }
+                else
+                {
+                    services.AddTransient<IUserService, UserService>();
+                }
+                
+                services.AddTransient<AuthorizeDriver>();
+
+                // document storage client
                 string documentStorageAdapterURI = _configuration["DOCUMENT_STORAGE_ADAPTER_URI"];
                 if (true || string.IsNullOrEmpty(documentStorageAdapterURI))
                 {
@@ -37,11 +86,8 @@ namespace Rsbc.Dmf.DriverPortal.Tests
                 {
                     services.AddDocumentStorageClient(_configuration);
                 }
-            });
 
-            // case management client
-            builder.ConfigureTestServices(services =>
-            {
+                // case management client
                 string cmsAdapterURI = _configuration["CMS_ADAPTER_URI"];
                 if (string.IsNullOrEmpty(cmsAdapterURI))
                 {

--- a/driver-portal/src/Tests/CustomWebApplicationFactory.cs
+++ b/driver-portal/src/Tests/CustomWebApplicationFactory.cs
@@ -50,7 +50,7 @@ namespace Rsbc.Dmf.DriverPortal.Tests
                 var user = new ClaimsPrincipal();
                 var claims = new List<Claim>
                 {
-                    new Claim(ClaimTypes.Sid, "QPSETRIJEOMSARHBRNRPBVAIFL65V3YI"),
+                    new Claim(ClaimTypes.Sid, _configuration["USER_SUBJECT"] ?? "SubjectId"),
                     new Claim(ClaimTypes.Email, "Email"),
                     new Claim(ClaimTypes.Upn, $"ExternalSystemUserId"),
                     new Claim(ClaimTypes.GivenName, "FirstName"),

--- a/driver-portal/src/Tests/Integration/AuthorizedDocumentTests.cs
+++ b/driver-portal/src/Tests/Integration/AuthorizedDocumentTests.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.Configuration;
+using Rsbc.Dmf.DriverPortal.ViewModels;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Rsbc.Dmf.DriverPortal.Tests.Integration
+{
+    public class AuthorizedDocumentTests
+    {
+        public class AuthorizationDocumentTests : ApiIntegrationTestBase
+        {
+            public AuthorizationDocumentTests(IConfiguration configuration) : base(configuration, true) { }
+
+            [Fact]
+            public async Task Driver_Authorized()
+            {
+                var driverId = _configuration["DRIVER_WITH_USER"];
+                if (string.IsNullOrEmpty(driverId))
+                    return;
+
+                // get documents by driver id
+                var request = new HttpRequestMessage(HttpMethod.Get, $"{DRIVER_API_BASE}/{driverId}/Documents");
+                var caseDocuments = await HttpClientSendRequest<CaseDocuments>(request);
+
+                Assert.NotNull(caseDocuments);
+            }
+
+            [Fact]
+            public async Task Driver_Not_Authorized()
+            {
+                var driverId = _configuration["DRIVER_WITH_CALLBACKS"];
+                if (string.IsNullOrEmpty(driverId))
+                    return;
+
+                // get documents by driver id
+                var request = new HttpRequestMessage(HttpMethod.Get, $"{DRIVER_API_BASE}/{driverId}/Documents");
+
+                var response = await _client.SendAsync(request);
+
+                Assert.Equal(System.Net.HttpStatusCode.Unauthorized, response.StatusCode);
+            }
+        }
+    }
+}

--- a/driver-portal/src/Tests/Program.cs
+++ b/driver-portal/src/Tests/Program.cs
@@ -1,20 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Rsbc.Dmf.DriverPortal.Api;
-using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
-var services = builder.Services;
-var env = builder.Environment;
-
-services.AddControllersWithViews().AddJsonOptions(x =>
-{
-    x.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-    x.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-});
-
-services.AddAutoMapperSingleton(LoggerFactory.Create(loggingBuilder => loggingBuilder.AddConsole()));
 
 var app = builder.Build();
 app.MapControllerRoute("default", "{controller}/{action=Index}/{id?}");

--- a/driver-portal/src/Tests/Startup.cs
+++ b/driver-portal/src/Tests/Startup.cs
@@ -8,8 +8,6 @@ namespace Rsbc.Dmf.DriverPortal.Tests
 {
     public class Startup
     {
-
-
         /// <summary>
         /// Register dependencies needed for xunit tests
         /// NOTE to register dependencies used by making calls from HttpClient, use CustomWebApplicationFactory
@@ -21,7 +19,7 @@ namespace Rsbc.Dmf.DriverPortal.Tests
                 .AddUserSecrets<ApplicationVersionInfo>()
                 .AddEnvironmentVariables()
                 .Build();
-            services.AddSingleton(_configuration);
+            services.AddSingleton<IConfiguration>(_configuration);
 
             using var loggerFactory = LoggerFactory.Create(loggingBuilder => loggingBuilder
                 .SetMinimumLevel(LogLevel.Trace)

--- a/driver-portal/src/Tests/Startup.cs
+++ b/driver-portal/src/Tests/Startup.cs
@@ -8,19 +8,26 @@ namespace Rsbc.Dmf.DriverPortal.Tests
 {
     public class Startup
     {
+
+
+        /// <summary>
+        /// Register dependencies needed for xunit tests
+        /// NOTE to register dependencies used by making calls from HttpClient, use CustomWebApplicationFactory
+        /// </summary>
+        /// <param name="services">service collection</param>
         public void ConfigureServices(IServiceCollection services)
         {
-            var configuration = new ConfigurationBuilder()
+            var _configuration = new ConfigurationBuilder()
                 .AddUserSecrets<ApplicationVersionInfo>()
                 .AddEnvironmentVariables()
                 .Build();
+            services.AddSingleton(_configuration);
 
             using var loggerFactory = LoggerFactory.Create(loggingBuilder => loggingBuilder
                 .SetMinimumLevel(LogLevel.Trace)
+                // TODO see XUnit DI package website for a potentially cleaner way to do XUnitLoggerProvider
                 // see case adapter XUnitLoggerProvider for a logger that will work with xunit
                 .AddConsole());
-
-            services.AddSingleton<IConfiguration>(configuration);
             services.AddAutoMapperSingleton(loggerFactory);
         }
     }


### PR DESCRIPTION
this is a working driver authorization attribute. If we need to optimize the query, we can query once to cache the driver(s) linked to the user login and then just check the driver id is the cached driver

this assumes user does not have direct access to cms-adapter. If the user has access to cms-adapter, we will need to move the authorization to cms-adapter, to avoid the user skipping the controller and access cms-adapter directly