### PR TITLE
DFTDP-116 download file service

### DIFF
--- a/driver-portal/src/Controllers/DocumentController.cs
+++ b/driver-portal/src/Controllers/DocumentController.cs
@@ -66,7 +66,7 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
                         string fileName = Path.GetFileName(reply.Document.DocumentUrl);
                         string mimetype = DocumentUtils.GetMimeType(fileName);
                         Response.Headers.ContentDisposition = new Microsoft.Extensions.Primitives.StringValues($"inline; filename={fileName}");
-                        //Serilog.Log.Information($"Sending DocumentID {documentId} file {reply.Document.DocumentUrl} data size {fileContents?.Length}");
+                        _logger.LogInformation($"Sending DocumentID {documentId} file {reply.Document.DocumentUrl} data size {fileContents?.Length}");
                         return new FileContentResult(fileContents, mimetype)
                         {
                             FileDownloadName = $"{fileName}"

--- a/driver-portal/src/Controllers/DocumentController.cs
+++ b/driver-portal/src/Controllers/DocumentController.cs
@@ -1,0 +1,93 @@
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Pssg.DocumentStorageAdapter;
+using Rsbc.Dmf.CaseManagement.Service;
+using Rsbc.Dmf.DriverPortal.Api.Services;
+using System.Net;
+using static Pssg.DocumentStorageAdapter.DocumentStorageAdapter;
+
+namespace Rsbc.Dmf.DriverPortal.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class DocumentController : Controller
+    {
+        private readonly CaseManager.CaseManagerClient _cmsAdapterClient;
+        private readonly DocumentStorageAdapterClient _documentStorageAdapterClient;
+        private readonly IUserService _userService;
+        private readonly IMapper _mapper;
+        private readonly ILogger<DriverController> _logger;
+
+        public DocumentController(CaseManager.CaseManagerClient cmsAdapterClient, DocumentStorageAdapterClient documentStorageAdapterClient, IUserService userService, IMapper mapper, ILoggerFactory loggerFactory)
+        {
+            _cmsAdapterClient = cmsAdapterClient;
+            _documentStorageAdapterClient = documentStorageAdapterClient;
+            _userService = userService;
+            _mapper = mapper;
+            _logger = loggerFactory.CreateLogger<DriverController>();
+        }
+
+        /// <summary>
+        /// Get Document Content
+        /// </summary>
+        /// <param name="documentId"></param>
+        /// <returns></returns>
+        [HttpGet("{documentId}")]
+        [Authorize(Policy = Policy.Driver)]
+        [ProducesResponseType(401)]
+        [ProducesResponseType(500)]
+        [ActionName(nameof(GetDocument))]
+        public async Task<ActionResult> GetDocument([FromRoute] string documentId)
+        {
+            // call the back end
+            var reply = _cmsAdapterClient.GetLegacyDocument(new LegacyDocumentRequest() { DocumentId = documentId });
+
+            if (reply.ResultStatus == CaseManagement.Service.ResultStatus.Success)
+            {
+                // check driver is authorized to view document
+                var profile = await _userService.GetCurrentUserContext();
+                if (reply.Document.Driver?.Id != profile.DriverId)
+                {
+                    return StatusCode((int)HttpStatusCode.Unauthorized, $"Not authorized - you are not authorized to view document {documentId}");
+                }
+
+                if (!string.IsNullOrEmpty(reply.Document?.DocumentUrl))
+                {
+                    // fetch the file from S3
+                    var downloadFileRequest = new DownloadFileRequest()
+                    {
+                        ServerRelativeUrl = reply.Document.DocumentUrl
+                    };
+                    var documentReply = _documentStorageAdapterClient.DownloadFile(downloadFileRequest);
+                    if (documentReply.ResultStatus == Pssg.DocumentStorageAdapter.ResultStatus.Success)
+                    {
+                        byte[] fileContents = documentReply.Data.ToByteArray();
+                        string fileName = Path.GetFileName(reply.Document.DocumentUrl);
+                        string mimetype = DocumentUtils.GetMimeType(fileName);
+                        Response.Headers.ContentDisposition = new Microsoft.Extensions.Primitives.StringValues($"inline; filename={fileName}");
+                        //Serilog.Log.Information($"Sending DocumentID {documentId} file {reply.Document.DocumentUrl} data size {fileContents?.Length}");
+                        return new FileContentResult(fileContents, mimetype)
+                        {
+                            FileDownloadName = $"{fileName}"
+                        };
+                    }
+                    else
+                    {
+                        _logger.LogError($"Unexpected error - unable to fetch file from storage  id - {documentId} - {reply.ErrorDetail}");
+                        return StatusCode((int)HttpStatusCode.InternalServerError, "Unexpected error - unable to fetch file from storage");
+                    }
+                }
+                else
+                {
+                    return StatusCode((int)HttpStatusCode.NotFound, $"Not found - document id {documentId} URL is missing from document object");
+                }
+            }
+            else
+            {
+                _logger.LogError($"Unexpected error - unable to get document meta-data for id {documentId} - {reply.ErrorDetail}");
+                return StatusCode((int)HttpStatusCode.InternalServerError, reply.ErrorDetail);
+            }
+        }
+    }
+}

--- a/driver-portal/src/Model/DocumentUtils.cs
+++ b/driver-portal/src/Model/DocumentUtils.cs
@@ -1,0 +1,27 @@
+﻿namespace Rsbc.Dmf.DriverPortal.Api
+{
+    public class DocumentUtils
+    {
+        /// <summary>
+        /// GetMimeType
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <returns></returns>
+        static public string GetMimeType(string filename)
+        {
+            string mimetype = "application/pdf";
+
+            if (!string.IsNullOrEmpty(filename))
+            {
+                string extension = Path.GetExtension(filename);
+
+                if (extension != null && (".tif" == extension.ToLower() || ".tiff" == extension.ToLower()))
+                {
+                    mimetype = "image/tiff";
+                }
+            }
+
+            return mimetype;
+        }
+    }
+}

--- a/driver-portal/src/Model/DocumentUtils.cs
+++ b/driver-portal/src/Model/DocumentUtils.cs
@@ -1,5 +1,7 @@
 ﻿namespace Rsbc.Dmf.DriverPortal.Api
 {
+    // get mime mappings from here
+    // https://github.com/Microsoft/referencesource/blob/master/System.Web/MimeMapping.cs
     public class DocumentUtils
     {
         /// <summary>

--- a/driver-portal/src/Tests/ApiIntegrationTestBase.cs
+++ b/driver-portal/src/Tests/ApiIntegrationTestBase.cs
@@ -12,6 +12,7 @@ namespace Rsbc.Dmf.DriverPortal.Tests
         protected readonly IConfiguration _configuration;
         protected const string CASE_API_BASE = "/api/Cases";
         protected const string DRIVER_API_BASE = "/api/Driver";
+        protected const string DOCUMENT_API_BASE = "/api/Document";
 
         public ApiIntegrationTestBase(IConfiguration configuration)
         {

--- a/driver-portal/src/Tests/Integration/DocumentTests.cs
+++ b/driver-portal/src/Tests/Integration/DocumentTests.cs
@@ -61,7 +61,7 @@ namespace Rsbc.Dmf.DriverPortal.Tests.Integration
         {
             // random guid
             var docId = "111a5c4c-a23e-ed11-b834-005056830000";
-            if (string.IsNullOrEmpty(docId))
+            if (string.IsNullOrEmpty(_configuration["ICBC_TEST_DL"]))
                 return;
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"{DOCUMENT_API_BASE}/{docId}");

--- a/driver-portal/src/Tests/Integration/DocumentTests.cs
+++ b/driver-portal/src/Tests/Integration/DocumentTests.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
-using Rsbc.Dmf.DriverPortal.ViewModels;
-using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -12,30 +12,64 @@ namespace Rsbc.Dmf.DriverPortal.Tests.Integration
         public DocumentTests(IConfiguration configuration) : base(configuration) { }
 
         [Fact]
-        public async Task GetLettersToDriver()
+        public async Task Download_Document()
         {
-            var driverId = _configuration["DRIVER_WITH_USER"];
-            if (string.IsNullOrEmpty(driverId))
+            var docId = _configuration["DOWNLOAD_DOC_ID"];
+            if (string.IsNullOrEmpty(docId))
                 return;
 
-            // get documents by driver id
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{DRIVER_API_BASE}/Documents");
-            var caseDocuments = await HttpClientSendRequest<CaseDocuments>(request);
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{DOCUMENT_API_BASE}/{docId}");
+            var response = await _client.SendAsync(request);
 
-            Assert.NotNull(caseDocuments);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var input = await response.Content.ReadAsStreamAsync();
+            var memoryStream = new MemoryStream();
+            input.CopyTo(memoryStream);
+
+            Assert.True(memoryStream.Length > 100);
         }
 
         [Fact]
-        public async Task Get_All_Documents()
+        public async Task Download_Document_No_Url()
         {
-            var driverId = _configuration["DOCS_DRIVER_ID"];
-            if (string.IsNullOrEmpty(driverId))
+            var docId = _configuration["NO_DOWNLOAD_DOC_ID"];
+            if (string.IsNullOrEmpty(docId))
                 return;
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{DRIVER_API_BASE}/AllDocuments");
-            var result = await HttpClientSendRequest<IEnumerable<Document>>(request);
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{DOCUMENT_API_BASE}/{docId}");
+            var response = await _client.SendAsync(request);
 
-            Assert.NotNull(result);
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Download_Document_Malformed_Url()
+        {
+            var docId = _configuration["DOWNLOAD_DOC_MALFORMED_URL"];
+            if (string.IsNullOrEmpty(docId))
+                return;
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{DOCUMENT_API_BASE}/{docId}");
+            var response = await _client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Download_Document_Fake_Id()
+        {
+            // random guid
+            var docId = "111a5c4c-a23e-ed11-b834-005056830000";
+            if (string.IsNullOrEmpty(docId))
+                return;
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{DOCUMENT_API_BASE}/{docId}");
+            var response = await _client.SendAsync(request);
+
+            // TODO refactor GetLegacyDocument to return NotFound
+            //Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
         }
     }
 }

--- a/driver-portal/src/Tests/Integration/DriverTests.cs
+++ b/driver-portal/src/Tests/Integration/DriverTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.Configuration;
+using Rsbc.Dmf.DriverPortal.ViewModels;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Rsbc.Dmf.DriverPortal.Tests.Integration
+{
+    public class DriverTests : ApiIntegrationTestBase
+    {
+        public DriverTests(IConfiguration configuration) : base(configuration) { }
+        
+        [Fact]
+        public async Task GetLettersToDriver()
+        {
+            var driverId = _configuration["DRIVER_WITH_USER"];
+            if (string.IsNullOrEmpty(driverId))
+                return;
+
+            // get documents by driver id
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{DRIVER_API_BASE}/Documents");
+            var caseDocuments = await HttpClientSendRequest<CaseDocuments>(request);
+
+            Assert.NotNull(caseDocuments);
+        }
+
+        [Fact]
+        public async Task Get_All_Documents()
+        {
+            var driverId = _configuration["DOCS_DRIVER_ID"];
+            if (string.IsNullOrEmpty(driverId))
+                return;
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{DRIVER_API_BASE}/AllDocuments");
+            var result = await HttpClientSendRequest<IEnumerable<Document>>(request);
+
+            Assert.NotNull(result);
+        }
+    }
+}

--- a/driver-portal/src/Tests/Rsbc.Dmf.DriverPortal.Tests.csproj
+++ b/driver-portal/src/Tests/Rsbc.Dmf.DriverPortal.Tests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup>
+	<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.25" />


### PR DESCRIPTION
Add download file service and 4 integration tests

Currently, the only mime types accepted are pdf and tiff. If another file extension is used then it will default to pdf. Once we establish what mime types we want to use and want to do when unaccepted mime type is used, then I can update DocumentUtils.GetMimeType