### PR TITLE
DFTDP-123 start of document type fix the owner

### DIFF
--- a/driver-portal/src/ClientApp/src/app/submission-requirements/submission-requirements.component.html
+++ b/driver-portal/src/ClientApp/src/app/submission-requirements/submission-requirements.component.html
@@ -57,7 +57,7 @@
               <mat-icon> file_present </mat-icon>
               <div>
                 <p>
-                  <a>Brouse</a> your file <br />
+                  Browse your file <br />
                   File Upload Specifications <br />
                   Maximum file size: 20MB <br />
                   Accepted file types: PDF, DOCX, PNG

--- a/driver-portal/src/ClientApp/src/app/submission-requirements/submission-requirements.component.ts
+++ b/driver-portal/src/ClientApp/src/app/submission-requirements/submission-requirements.component.ts
@@ -97,8 +97,9 @@ export class SubmissionRequirementsComponent {
 
     const formData = new FormData();
     formData.append('file', this.fileToUpload as File);
-
-    // formData.append('documentType', this.selectedValue);
+    if (this.selectedValue) {
+      formData.append('documentTypeCode', this.selectedValue);
+    }
 
     this._http
       .post(`${this.apiConfig.rootUrl}/api/Document/upload`, formData, {

--- a/driver-portal/src/Controllers/DocumentController.cs
+++ b/driver-portal/src/Controllers/DocumentController.cs
@@ -111,7 +111,7 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
         // to save time, we opted to just write this api call manually on the frontend
         [ApiExplorerSettings(IgnoreApi = true)]
 
-        public async Task<IActionResult> UploadDriverDocument([FromForm] IFormFile file)
+        public async Task<IActionResult> UploadDriverDocument([FromForm] IFormFile file, [FromForm] string documentTypeCode)
         {
             // sanity check paramters
             if (string.IsNullOrEmpty(file?.FileName) || file.Length == 0)
@@ -153,7 +153,13 @@ namespace Rsbc.Dmf.DriverPortal.Api.Controllers
             // create document and then link to driver
             var driver = new Driver();
             driver.Id = profile.DriverId;
-            var document = _documentFactory.Create(driver, profile.Id, fileReply.FileName);
+
+            // TODO temporary code
+            var documentType = "Diabetic Doctor Report";
+            if (documentTypeCode == "001") documentType = "DMER";
+            if (documentTypeCode == "030") documentType = "EVF";
+
+            var document = _documentFactory.Create(driver, profile.Id, documentType, documentTypeCode, fileReply.FileName);
             var result = _cmsAdapterClient.CreateDocumentOnDriver(document);
             if (result.ResultStatus != CaseManagement.Service.ResultStatus.Success)
             {

--- a/driver-portal/src/Model/DocumentFactory.cs
+++ b/driver-portal/src/Model/DocumentFactory.cs
@@ -5,7 +5,7 @@ namespace Rsbc.Dmf.DriverPortal.Api
 {
     public class DocumentFactory
     {
-        public LegacyDocument Create(Driver driver, string userId, string documentUrl, string caseId = "")
+        public LegacyDocument Create(Driver driver, string userId, string documentUrl, string documentType, string documentTypeCode, string caseId = "")
         {
             var importDate = DateTimeOffset.Now;
             var faxReceivedDate = DateTimeOffset.Now;
@@ -27,17 +27,13 @@ namespace Rsbc.Dmf.DriverPortal.Api
                 FaxReceivedDate = Timestamp.FromDateTimeOffset(faxReceivedDate),
                 ImportDate = Timestamp.FromDateTimeOffset(importDate),
                 Driver = driver,
-
-                // TODO if you want to use this function in a more generic way
-                // use CaseManager.GetDocumentType to populate the following 3 lines
-                DocumentTypeCode = "001",
-                DocumentType = "DMER",
-                BusinessArea = "Driver Fitness",
-
+                DocumentTypeCode = documentTypeCode,
+                DocumentType = documentType,
+                BusinessArea = "",
                 DocumentUrl = documentUrl,
                 Priority = string.Empty,
-                // TODO
-                Owner = string.Empty,
+                // maps to "Intake Team"
+                Owner = "Client Services",
                 BatchId = string.Empty,
                 ValidationMethod = string.Empty,
                 ValidationPrevious = string.Empty,


### PR DESCRIPTION
Set owner to be intake team on upload file service

Pass document type code to backend service upload file. For now use temporary code to map the document type. Once I have the document type list and we decide if that is a code list or a database table, I can finish the document type validation for upload file service.

I see the files in submission history but looks like the submission type needs to be changed. I have not tested that I can download the file after uploading, I did not see any place to download the file on the frontend.