### PR TITLE
DFTDP-123 upload document now links document sub type

### DIFF
--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
@@ -209,38 +209,6 @@ message LegacyComment {
 	string SignatureName = 10;
 }
 
-message LegacyDocument {
-	int64 SequenceNumber = 1;
-	string DocumentTypeCode = 2;
-	string DocumentType = 3;
-	string BusinessArea = 4;
-	string DocumentUrl = 5;
-	string UserId = 6;
-	string CaseId = 7;
-	string DocumentId = 8;	
-	google.protobuf.Timestamp FaxReceivedDate = 9;
-	google.protobuf.Timestamp ImportDate = 10;
-	string ImportId = 11;
-	Driver Driver = 12;
-	string BatchId = 13;
-	string OriginatingNumber = 14;
-	int64 DocumentPages = 15;
-	string ValidationMethod = 16;
-	string ValidationPrevious = 17;
-	string Priority = 18;
-	string Owner = 19;
-	string SubmittalStatus = 20;
-	string Queue = 21;
-	int64 DpsDocumentId = 22;
-	string FilenameOverride = 23;
-	string Origin = 24;
-	google.protobuf.Timestamp CreateDate = 25;
-	google.protobuf.Timestamp DueDate = 26;
-	string Description = 27;
-	string IdCode = 28;
-	string CaseType = 29;
-}
-
 message GetDocumentRequest {	
 	string documentId = 1;
 }
@@ -488,9 +456,49 @@ message DecisionItem {
 	DecisionOutcomeOptions outcome = 3;
 }
 
+////////////////////////
 // START DocumentManager
+
 service DocumentManager {
 	rpc GetDocumentSubTypes(DocumentTypeRequest) returns (GetDocumentSubTypesReply);
+	rpc GetDocumentSubTypeGuid(DocumentIdRequest) returns (GetDocumentSubTypeIdReply);
+}
+
+message LegacyDocument {
+	int64 SequenceNumber = 1;
+	string DocumentTypeCode = 2;
+	string DocumentType = 3;
+	string BusinessArea = 4;
+	string DocumentUrl = 5;
+	string UserId = 6;
+	string CaseId = 7;
+	string DocumentId = 8;	
+	google.protobuf.Timestamp FaxReceivedDate = 9;
+	google.protobuf.Timestamp ImportDate = 10;
+	string ImportId = 11;
+	Driver Driver = 12;
+	string BatchId = 13;
+	string OriginatingNumber = 14;
+	int64 DocumentPages = 15;
+	string ValidationMethod = 16;
+	string ValidationPrevious = 17;
+	string Priority = 18;
+	string Owner = 19;
+	string SubmittalStatus = 20;
+	string Queue = 21;
+	int64 DpsDocumentId = 22;
+	string FilenameOverride = 23;
+	string Origin = 24;
+	google.protobuf.Timestamp CreateDate = 25;
+	google.protobuf.Timestamp DueDate = 26;
+	string Description = 27;
+	string IdCode = 28;
+	string CaseType = 29;
+	string DocumentSubTypeId = 30;
+}
+
+message DocumentIdRequest {
+	int32 id = 1;
 }
 
 message DocumentTypeRequest {
@@ -508,7 +516,15 @@ message GetDocumentSubTypesReply {
 	string errorDetail = 3;
 }
 
+message GetDocumentSubTypeIdReply {
+	string id = 1;
+	ResultStatus resultStatus = 2;
+	string errorDetail = 3;
+}
+
 // END DocumentManager
+////////////////////////
+// START CssManager
 
 service CssManager {
 	rpc GetCss(CssRequest) returns (CssReply);
@@ -523,6 +539,9 @@ message CssReply {
 	string errorDetail = 2;
 	string css = 3; 
 }
+
+// END CssManager
+////////////////////////
 
 service UserManager {
   rpc Search (UsersSearchRequest) returns (UsersSearchReply);
@@ -633,7 +652,7 @@ message ResultStatusReply {
 	string errorDetail = 2;
 }
 
-enum  BringForwardPriority{
+enum BringForwardPriority{
 	Low = 0;
 	Normal = 1;
 	High = 2;

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/CaseService.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/CaseService.cs
@@ -154,8 +154,6 @@ namespace Rsbc.Dmf.CaseManagement.Service
                 reply.ErrorDetail = result.ErrorDetail ?? string.Empty;
             }
 
-
-
             return reply;
         }
 
@@ -200,7 +198,8 @@ namespace Rsbc.Dmf.CaseManagement.Service
                 SubmittalStatus = request.SubmittalStatus ?? string.Empty,
                 Queue = request.Queue ?? string.Empty,
                 DpsDocumentId = request.DpsDocumentId,
-                Origin = request.Origin
+                Origin = request.Origin,
+                DocumentSubTypeId = request.DocumentSubTypeId ?? string.Empty
             };
 
             if (request.FaxReceivedDate != null)

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/DocumentService.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/DocumentService.cs
@@ -9,12 +9,14 @@ using Microsoft.Extensions.Configuration;
 namespace Rsbc.Dmf.CaseManagement.Service
 {
     // DOMAIN documents, document types, document sub types, submittal types
+
     public class DocumentService : DocumentManager.DocumentManagerBase
     {
         private readonly IDocumentTypeManager _documentTypeManager;
         private readonly IMapper _mapper;
         private readonly IConfiguration _configuration;
         private readonly ILogger<DocumentService> _logger;
+        private readonly string _driverDocumentTypeCode;
 
         public DocumentService(IDocumentTypeManager documentTypeManager, IMapper mapper, IConfiguration configuraiton, ILoggerFactory loggerFactory)
         {
@@ -22,6 +24,29 @@ namespace Rsbc.Dmf.CaseManagement.Service
             _mapper = mapper;
             _configuration = configuraiton;
             _logger = loggerFactory.CreateLogger<DocumentService>();
+            _driverDocumentTypeCode = _configuration["DRIVER_DOCUMENT_TYPE_CODE"];
+        }
+
+        // get Guid from document sub type that is in the set of documents belonging to 666
+        // use this in conjunction with GetDocumentsSubTypes method
+        public async override Task<GetDocumentSubTypeIdReply> GetDocumentSubTypeGuid(DocumentIdRequest request, ServerCallContext context)
+        {
+            var reply = new GetDocumentSubTypeIdReply();
+
+            try
+            {
+                reply.Id = _documentTypeManager
+                    .GetDocumentSubTypeGuid(request.Id, _driverDocumentTypeCode)
+                    .ToString();
+                reply.ResultStatus = ResultStatus.Success;
+            }
+            catch (Exception ex)
+            {
+                reply.ErrorDetail = ex.Message;
+                reply.ResultStatus = ResultStatus.Fail;
+            }
+
+            return reply;
         }
 
         public async override Task<GetDocumentSubTypesReply> GetDocumentSubTypes(DocumentTypeRequest request, ServerCallContext context)
@@ -32,7 +57,7 @@ namespace Rsbc.Dmf.CaseManagement.Service
             {
                 // validation
                 // NOTE for now only 666 code is allowed
-                if (request.DocumentTypeCode != _configuration["DRIVER_DOCUMENT_TYPE_CODE"])
+                if (request.DocumentTypeCode != _driverDocumentTypeCode)
                 {
                     reply.ResultStatus = ResultStatus.Fail;
                     reply.ErrorDetail = "Invalid document type code";

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Dynamics/Mapper/DocumentTypeMapper.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Dynamics/Mapper/DocumentTypeMapper.cs
@@ -9,12 +9,8 @@ namespace Rsbc.Dmf.CaseManagement.Dynamics
         {
             public DocumentTypeAutoMapperProfile()
             {
-                // NOTE somehow the id keeps incrementing on each test run, not sure how that is possible
-                int id = 0;
-
                 CreateMap<dfp_documentsubtype, DocumentSubType>()
-                    .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.dfp_name))
-                    .AfterMap((src, dest) => { dest.Id = id++; });
+                    .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.dfp_name));
             }
         }
     }

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/CaseManager.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/CaseManager.cs
@@ -82,6 +82,7 @@ namespace Rsbc.Dmf.CaseManagement
         public DateTimeOffset CreateDate { get; set; }
         public DateTimeOffset? DueDate { get; set; }
         public string Description { get; set; }
+        public string DocumentSubTypeId { get; set; }
     }
 
     public class CreateStatusReply
@@ -1388,9 +1389,11 @@ namespace Rsbc.Dmf.CaseManagement
             {
                 try
                 {
-                    var record = dynamicsContext.dfp_submittaltypes.Where(d => d.dfp_apidocumenttype == documentTypeCode).FirstOrDefault();
-                    result = record;
-
+                    result = dynamicsContext.dfp_submittaltypes.Where(d => d.dfp_apidocumenttype == documentTypeCode).FirstOrDefault();
+                    if (result == null)
+                    {
+                        result = dynamicsContext.dfp_submittaltypes.Where(d => d.dfp_code == documentTypeCode).FirstOrDefault();
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -1696,6 +1699,15 @@ namespace Rsbc.Dmf.CaseManagement
                         dynamicsContext.UpdateObject(bcgovDocumentUrl);
                         dynamicsContext.SetLink(bcgovDocumentUrl, nameof(bcgov_documenturl.dfp_DocumentTypeID), documentTypeId);
                         dynamicsContext.SetLink(bcgovDocumentUrl, nameof(bcgov_documenturl.dfp_DriverId), searchdriver);
+                        if (request.DocumentSubTypeId != null)
+                        {
+                            var documentSubType = dynamicsContext.dfp_documentsubtypes.Where(d => d.dfp_documentsubtypeid == Guid.Parse(request.DocumentSubTypeId))
+                                .FirstOrDefault();
+                            if (documentSubType != null)
+                            {
+                                dynamicsContext.SetLink(bcgovDocumentUrl, nameof(bcgov_documenturl.dfp_DocumentSubType), documentSubType);
+                            }
+                        }
 
                         await dynamicsContext.SaveChangesAsync();
                         result.Success = true;
@@ -1707,7 +1719,7 @@ namespace Rsbc.Dmf.CaseManagement
                         result.Success = false;
                     }
                 }
-                else
+                else // insert
                 {
                     try
                     {
@@ -1731,8 +1743,16 @@ namespace Rsbc.Dmf.CaseManagement
                         {
                             dynamicsContext.SetLink(bcgovDocumentUrl, nameof(bcgovDocumentUrl.ownerid), newOwner);
                         }
+                        if (request.DocumentSubTypeId != null)
+                        {
+                            var documentSubType = dynamicsContext.dfp_documentsubtypes.Where(d => d.dfp_documentsubtypeid == Guid.Parse(request.DocumentSubTypeId))
+                                .FirstOrDefault();
+                            if (documentSubType != null)
+                            {
+                                dynamicsContext.SetLink(bcgovDocumentUrl, nameof(bcgov_documenturl.dfp_DocumentSubType), documentSubType);
+                            }
+                        }
 
-                        
 
                         if (!string.IsNullOrEmpty(request.CaseId))
                         {

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/DocumentTypeManager.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/DocumentTypeManager.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Rsbc.Dmf.CaseManagement.Dynamics;
+using Rsbc.Dmf.Dynamics.Microsoft.Dynamics.CRM;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,6 +19,7 @@ namespace Rsbc.Dmf.CaseManagement
 
     public interface IDocumentTypeManager
     {
+        Guid GetDocumentSubTypeGuid(int id, string documentTypeCode);
         IEnumerable<DocumentSubType> GetDocumentSubTypes(string documentTypeCode);
     }
 
@@ -35,13 +38,43 @@ namespace Rsbc.Dmf.CaseManagement
             _mapper = mapper;
         }
 
+        public Guid GetDocumentSubTypeGuid(int id, string documentTypeCode)
+        {
+            var documentSubTypes = GetDynamicsDocumentSubTypes(documentTypeCode).ToList();
+            var mappedDocumentSubTypes = MapDocumentSubTypeId(documentSubTypes).ToList();
+            var documentSubTypeIndex = mappedDocumentSubTypes.FindIndex(dst => dst.Id == id);
+            return documentSubTypes[documentSubTypeIndex].dfp_documentsubtypeid.Value;
+        }
+
         public IEnumerable<DocumentSubType> GetDocumentSubTypes(string documentTypeCode)
         {
+            var documentSubTypes = GetDynamicsDocumentSubTypes(documentTypeCode);
+            return MapDocumentSubTypeId(documentSubTypes);
+        }
+
+        private IEnumerable<dfp_documentsubtype> GetDynamicsDocumentSubTypes(string documentTypeCode)
+        {
             var documentSubTypes = _dynamicsContext.dfp_documentsubtypes
-                .Expand(dt => dt.dfp_DocumentTypeID)
+                .Expand(dst => dst.dfp_DocumentTypeID)
                 .Where(dst => dst.dfp_DocumentTypeID.dfp_code == documentTypeCode)
+                .OrderBy(dst => dst.dfp_name)
+                // to guarantee the same order even when names are the same
+                .OrderBy(dst => dst.dfp_documentsubtypeid)
                 .ToList();
-            return _mapper.Map<IEnumerable<DocumentSubType>>(documentSubTypes);
+
+            return documentSubTypes;
+        }
+
+        private IEnumerable<DocumentSubType> MapDocumentSubTypeId(IEnumerable<dfp_documentsubtype> documentSubTypes)
+        {
+            var mappedDocumentSubTypes = _mapper.Map<IEnumerable<DocumentSubType>>(documentSubTypes);
+            int id = 0;
+            foreach (var documentSubType in mappedDocumentSubTypes)
+            {
+                documentSubType.Id = id++;
+            }
+
+            return mappedDocumentSubTypes;
         }
     }
 }


### PR DESCRIPTION
This part is hacky:

```
result = dynamicsContext.dfp_submittaltypes.Where(d => d.dfp_apidocumenttype == documentTypeCode).FirstOrDefault();
if (result == null)
{
    result = dynamicsContext.dfp_submittaltypes.Where(d => d.dfp_code == documentTypeCode).FirstOrDefault();
}
```

but the only way to avoid this awkward flow is to create a new method instead of reusing CaseManager.CreateDocumentOnDriver, which I'm not opposed to