### PR TITLE
DFTDP-100 Cancel Callback Backend Service

### DIFF
--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
@@ -116,9 +116,11 @@ service CaseManager {
   rpc UpdateNonComplyDocuments(EmptyRequest) returns (ResultStatusReply);
 }
 
+// sync with EntityState enum in Rsbc.Dmf.CaseManagement\Dynamics\DynamicsContext.cs
 enum EntityState {
     Active = 0;
     Inactive = 1;
+    Cancelled = 2;
 }
 
 message UpdateDriverRequest{

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
@@ -667,10 +667,6 @@ service CallbackManager {
     rpc Cancel (CallbackCancelRequest) returns (ResultStatusReply);
 }
 
-message CallbackIdRequest {
-    string id = 1;
-}
-
 message CallbackCancelRequest {
     string caseId = 1;
     string callbackId = 2;

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
@@ -664,11 +664,16 @@ message ResultStatusReply {
 
 service CallbackManager {
     rpc GetDriverCallbacks (DriverIdRequest) returns (GetDriverCallbacksReply);
-    rpc Cancel (CallbackIdRequest) returns (ResultStatusReply);
+    rpc Cancel (CallbackCancelRequest) returns (ResultStatusReply);
 }
 
 message CallbackIdRequest {
     string id = 1;
+}
+
+message CallbackCancelRequest {
+    string caseId = 1;
+    string callbackId = 2;
 }
 
 enum BringForwardPriority{

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Protos/cmsAdapter.proto
@@ -661,7 +661,12 @@ message ResultStatusReply {
 // START CallbackManager
 
 service CallbackManager {
-  rpc GetDriverCallbacks (DriverIdRequest) returns (GetDriverCallbacksReply);
+    rpc GetDriverCallbacks (DriverIdRequest) returns (GetDriverCallbacksReply);
+    rpc Cancel (CallbackIdRequest) returns (ResultStatusReply);
+}
+
+message CallbackIdRequest {
+    string id = 1;
 }
 
 enum BringForwardPriority{

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/CallbackService.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/CallbackService.cs
@@ -41,14 +41,15 @@ namespace Rsbc.Dmf.CaseManagement.Service
             return reply;
         }
 
-        public async override Task<ResultStatusReply> Cancel(CallbackIdRequest request, ServerCallContext context)
+        public async override Task<ResultStatusReply> Cancel(CallbackCancelRequest request, ServerCallContext context)
         {
             var reply = new ResultStatusReply();
 
             try
             {
-                var callbackId = Guid.Parse(request.Id);
-                var result = await _callbackManager.Cancel(callbackId);
+                var callbackId = Guid.Parse(request.CallbackId);
+                var caseId = Guid.Parse(request.CaseId);
+                var result = await _callbackManager.Cancel(caseId, callbackId);
                 if (result.Success)
                 {
                     reply.ResultStatus = ResultStatus.Success;

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/CallbackService.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Service/Services/CallbackService.cs
@@ -40,5 +40,32 @@ namespace Rsbc.Dmf.CaseManagement.Service
 
             return reply;
         }
+
+        public async override Task<ResultStatusReply> Cancel(CallbackIdRequest request, ServerCallContext context)
+        {
+            var reply = new ResultStatusReply();
+
+            try
+            {
+                var callbackId = Guid.Parse(request.Id);
+                var result = await _callbackManager.Cancel(callbackId);
+                if (result.Success)
+                {
+                    reply.ResultStatus = ResultStatus.Success;
+                }
+                else
+                {
+                    reply.ResultStatus = ResultStatus.Fail;
+                    reply.ErrorDetail = result.ErrorDetail;
+                }
+            }
+            catch (Exception ex)
+            {
+                reply.ErrorDetail = ex.Message;
+                reply.ResultStatus = ResultStatus.Fail;
+            }
+
+            return reply;
+        }
     }
 }

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Dynamics/DynamicsContext.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Dynamics/DynamicsContext.cs
@@ -76,9 +76,12 @@ namespace Rsbc.Dmf.CaseManagement.Dynamics
         }
     }
 
+    // sync with EntityState enum in Rsbc.Dmf.CaseManagement.Service\Protos\cmsAdapter.proto
     public enum EntityState
     {
         Active = 0,
-        Inactive = 1
+        Inactive = 1,
+        Cancelled = 2,
+        //Pending = 3?
     }
 }

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/Callback/CallbackManager.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/Callback/CallbackManager.cs
@@ -51,5 +51,26 @@ namespace Rsbc.Dmf.CaseManagement
 
             return results;
         }
+
+        public async Task<ResultStatusReply> Cancel(Guid callbackId)
+        {
+            var reply = new ResultStatusReply();
+
+            try
+            {
+                var task = _dynamicsContext.tasks.Single(t => t.activityid == callbackId);
+                task.statecode = (int)EntityState.Inactive;
+                await _dynamicsContext.SaveChangesAsync();
+                reply.Success = true;
+            } 
+            catch (Exception ex) 
+            {
+                _logger.LogError(ex, $"{nameof(Cancel)} failed.");
+                reply.Success = false;
+                reply.ErrorDetail = ex.Message;
+            }
+
+            return reply;
+        }
     }
 }

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/Callback/ICallbackManager.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/Callback/ICallbackManager.cs
@@ -7,6 +7,6 @@ namespace Rsbc.Dmf.CaseManagement
     public interface ICallbackManager
     {
         Task<IEnumerable<Callback>> GetDriverCallbacks(Guid driverId);
-        Task<ResultStatusReply> Cancel(Guid callbackId);
+        Task<ResultStatusReply> Cancel(Guid caseId, Guid callbackId);
     }
 }

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/Callback/ICallbackManager.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/Callback/ICallbackManager.cs
@@ -7,5 +7,6 @@ namespace Rsbc.Dmf.CaseManagement
     public interface ICallbackManager
     {
         Task<IEnumerable<Callback>> GetDriverCallbacks(Guid driverId);
+        Task<ResultStatusReply> Cancel(Guid callbackId);
     }
 }

--- a/driver-portal/src/Tests/Integration/CallbackTests.cs
+++ b/driver-portal/src/Tests/Integration/CallbackTests.cs
@@ -46,5 +46,26 @@ namespace Rsbc.Dmf.DriverPortal.Tests.Integration
 
             Assert.NotNull(response);
         }
+
+        // NOTE you can use create callback integration test to get a new callback id,
+        // if the callback no longer exists in dynamics 
+        [Fact]
+        public async Task Cancel_Callback()
+        {
+            var callbackId = _configuration["CALLBACK_ID"];
+            if (string.IsNullOrEmpty(callbackId))
+                return;
+
+            var callbackIdRequest = new CallbackIdRequest()
+            {
+                Id = callbackId,
+            };
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{CALLBACK_API_BASE}/cancel");
+            SetContent(request, callbackIdRequest);
+
+            var response = await _client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
     }
 }

--- a/driver-portal/src/Tests/Integration/CallbackTests.cs
+++ b/driver-portal/src/Tests/Integration/CallbackTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 using Rsbc.Dmf.CaseManagement.Service;
 using System.Net;
+using System;
 
 namespace Rsbc.Dmf.DriverPortal.Tests.Integration
 {
@@ -56,12 +57,8 @@ namespace Rsbc.Dmf.DriverPortal.Tests.Integration
             if (string.IsNullOrEmpty(callbackId))
                 return;
 
-            var callbackIdRequest = new CallbackIdRequest()
-            {
-                Id = callbackId,
-            };
             var request = new HttpRequestMessage(HttpMethod.Get, $"{CALLBACK_API_BASE}/cancel");
-            SetContent(request, callbackIdRequest);
+            SetContent(request, Guid.Parse(callbackId));
 
             var response = await _client.SendAsync(request);
 

--- a/rsbc-dmf.sln
+++ b/rsbc-dmf.sln
@@ -33,6 +33,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IcbcClient", "icbc-adapter\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedUtils", "shared-utils\SharedUtils.csproj", "{416A9869-BBA5-4DEC-866E-3206B702CE47}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rsbc.Dmf.LegacyAdapter", "legacy-adapter\src\Rsbc.Dmf.LegacyAdapter\Rsbc.Dmf.LegacyAdapter.csproj", "{BCF94157-465B-40D5-B3EB-7E7B7F481B3B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RSBC.DMF.MedicalPortal.API", "medical-portal\src\API\RSBC.DMF.MedicalPortal.API\RSBC.DMF.MedicalPortal.API.csproj", "{D25BE017-1765-4B57-94BE-E236A6C3D95F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "migration-metrics", "migration-metrics\src\migration-metrics.csproj", "{B17FBB67-39CC-4B7A-B1AF-4798633A72F2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OAuthServer", "oauth-server\src\OAuthServer\OAuthServer.csproj", "{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +103,22 @@ Global
 		{416A9869-BBA5-4DEC-866E-3206B702CE47}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{416A9869-BBA5-4DEC-866E-3206B702CE47}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{416A9869-BBA5-4DEC-866E-3206B702CE47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCF94157-465B-40D5-B3EB-7E7B7F481B3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCF94157-465B-40D5-B3EB-7E7B7F481B3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCF94157-465B-40D5-B3EB-7E7B7F481B3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCF94157-465B-40D5-B3EB-7E7B7F481B3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D25BE017-1765-4B57-94BE-E236A6C3D95F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D25BE017-1765-4B57-94BE-E236A6C3D95F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D25BE017-1765-4B57-94BE-E236A6C3D95F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D25BE017-1765-4B57-94BE-E236A6C3D95F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B17FBB67-39CC-4B7A-B1AF-4798633A72F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17FBB67-39CC-4B7A-B1AF-4798633A72F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17FBB67-39CC-4B7A-B1AF-4798633A72F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B17FBB67-39CC-4B7A-B1AF-4798633A72F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/rsbc-dmf.sln
+++ b/rsbc-dmf.sln
@@ -27,6 +27,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "S3", "document-storage-adap
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "driver-portal", "driver-portal\src\driver-portal.csproj", "{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pssg.Dmf.IcbcAdapter", "icbc-adapter\src\Pssg.Dmf.IcbcAdapter\Pssg.Dmf.IcbcAdapter.csproj", "{D4563D67-ECA6-456D-A4AF-9BEECFAF93D0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IcbcClient", "icbc-adapter\src\Pssg.Interfaces.Icbc\IcbcClient.csproj", "{BF11F3B3-3E9A-4D52-9B68-A644624CD97A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedUtils", "shared-utils\SharedUtils.csproj", "{416A9869-BBA5-4DEC-866E-3206B702CE47}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,6 +83,18 @@ Global
 		{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4563D67-ECA6-456D-A4AF-9BEECFAF93D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4563D67-ECA6-456D-A4AF-9BEECFAF93D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4563D67-ECA6-456D-A4AF-9BEECFAF93D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4563D67-ECA6-456D-A4AF-9BEECFAF93D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF11F3B3-3E9A-4D52-9B68-A644624CD97A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF11F3B3-3E9A-4D52-9B68-A644624CD97A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF11F3B3-3E9A-4D52-9B68-A644624CD97A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF11F3B3-3E9A-4D52-9B68-A644624CD97A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{416A9869-BBA5-4DEC-866E-3206B702CE47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{416A9869-BBA5-4DEC-866E-3206B702CE47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{416A9869-BBA5-4DEC-866E-3206B702CE47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{416A9869-BBA5-4DEC-866E-3206B702CE47}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/rsbc-dmf.sln
+++ b/rsbc-dmf.sln
@@ -1,0 +1,87 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pssg.DocumentStorageAdapter.Client", "document-storage-adapter\src\Pssg.DocumentStorageAdapter.Client\Pssg.DocumentStorageAdapter.Client.csproj", "{EB3D94BE-AC5D-4316-A604-5D45AFBF22D2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pssg.DocumentStorageAdapter.Moq", "document-storage-adapter\src\Pssg.DocumentStorageAdapter.Moq\Pssg.DocumentStorageAdapter.Moq.csproj", "{2BC79C2F-52EF-4EAA-B166-A09BDFC13513}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rsbc.Dmf.CaseManagement.Client", "cms-adapter\src\Rsbc.Dmf.CaseManagement.Client\Rsbc.Dmf.CaseManagement.Client.csproj", "{12418AB0-4406-4AEB-9376-0DBCA8970CBB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rsbc.Dmf.CaseManagement.Moq", "cms-adapter\src\Rsbc.Dmf.CaseManagement.Moq\Rsbc.Dmf.CaseManagement.Moq.csproj", "{77E2FD4A-7762-4A1F-B24E-B052B61350D6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D0A09E19-A9EB-452F-AF34-3B65784FE118}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rsbc.Dmf.BcMailAdapter", "bcmail-adapter\src\Rsbc.Dmf.BcMailAdapter\Rsbc.Dmf.BcMailAdapter.csproj", "{31591259-80D6-40C9-A26A-BB69592C0807}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CdgsServiceClient", "bcmail-adapter\src\Rsbc.Interfaces.Dmf.BcMailAdapter\CdgsServiceClient.csproj", "{4027FAE8-8B99-44EA-A8E4-E691F160282E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rsbc.Dmf.CaseManagement", "cms-adapter\src\Rsbc.Dmf.CaseManagement\Rsbc.Dmf.CaseManagement.csproj", "{BBD151FD-56D1-48CE-A40D-F365D3194F91}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rsbc.Dmf.CaseManagement.Service", "cms-adapter\src\Rsbc.Dmf.CaseManagement.Service\Rsbc.Dmf.CaseManagement.Service.csproj", "{E59FE234-123E-4C5C-8FFD-E4DD8B126638}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pssg.DocumentStorageAdapter", "document-storage-adapter\src\Pssg.DocumentStorageAdapter\Pssg.DocumentStorageAdapter.csproj", "{13B74735-60AE-4C95-839A-A45E2DFC6FAF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "S3", "document-storage-adapter\src\Pssg.Interfaces.S3\S3.csproj", "{470055C4-3267-468A-94AD-FC6E0D81360D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "driver-portal", "driver-portal\src\driver-portal.csproj", "{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EB3D94BE-AC5D-4316-A604-5D45AFBF22D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB3D94BE-AC5D-4316-A604-5D45AFBF22D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB3D94BE-AC5D-4316-A604-5D45AFBF22D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB3D94BE-AC5D-4316-A604-5D45AFBF22D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BC79C2F-52EF-4EAA-B166-A09BDFC13513}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BC79C2F-52EF-4EAA-B166-A09BDFC13513}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BC79C2F-52EF-4EAA-B166-A09BDFC13513}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BC79C2F-52EF-4EAA-B166-A09BDFC13513}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12418AB0-4406-4AEB-9376-0DBCA8970CBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12418AB0-4406-4AEB-9376-0DBCA8970CBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12418AB0-4406-4AEB-9376-0DBCA8970CBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12418AB0-4406-4AEB-9376-0DBCA8970CBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77E2FD4A-7762-4A1F-B24E-B052B61350D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77E2FD4A-7762-4A1F-B24E-B052B61350D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77E2FD4A-7762-4A1F-B24E-B052B61350D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77E2FD4A-7762-4A1F-B24E-B052B61350D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31591259-80D6-40C9-A26A-BB69592C0807}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31591259-80D6-40C9-A26A-BB69592C0807}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31591259-80D6-40C9-A26A-BB69592C0807}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31591259-80D6-40C9-A26A-BB69592C0807}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4027FAE8-8B99-44EA-A8E4-E691F160282E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4027FAE8-8B99-44EA-A8E4-E691F160282E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4027FAE8-8B99-44EA-A8E4-E691F160282E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4027FAE8-8B99-44EA-A8E4-E691F160282E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBD151FD-56D1-48CE-A40D-F365D3194F91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBD151FD-56D1-48CE-A40D-F365D3194F91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBD151FD-56D1-48CE-A40D-F365D3194F91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBD151FD-56D1-48CE-A40D-F365D3194F91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E59FE234-123E-4C5C-8FFD-E4DD8B126638}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E59FE234-123E-4C5C-8FFD-E4DD8B126638}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E59FE234-123E-4C5C-8FFD-E4DD8B126638}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E59FE234-123E-4C5C-8FFD-E4DD8B126638}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13B74735-60AE-4C95-839A-A45E2DFC6FAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13B74735-60AE-4C95-839A-A45E2DFC6FAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13B74735-60AE-4C95-839A-A45E2DFC6FAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13B74735-60AE-4C95-839A-A45E2DFC6FAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{470055C4-3267-468A-94AD-FC6E0D81360D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{470055C4-3267-468A-94AD-FC6E0D81360D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{470055C4-3267-468A-94AD-FC6E0D81360D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{470055C4-3267-468A-94AD-FC6E0D81360D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D82A8EE1-CDDD-4DDA-8336-EB09CCE86AA3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {271891BD-B82B-4608-BC8E-FAF1186A4461}
+	EndGlobalSection
+EndGlobal

--- a/rsbc-dmf.sln
+++ b/rsbc-dmf.sln
@@ -41,6 +41,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "migration-metrics", "migrat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OAuthServer", "oauth-server\src\OAuthServer\OAuthServer.csproj", "{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "phsa-adapter", "phsa-adapter\src\phsa-adapter.csproj", "{96412F26-6713-4895-A68B-3805B4077444}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "icbc-adapter-client", "interfaces\icbc-adapter\icbc-adapter-client.csproj", "{65AD788B-D452-48D4-8764-7D0173D9561D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rsbc.Dmf.Scheduler", "scheduler\src\Rsbc.Dmf.Scheduler\Rsbc.Dmf.Scheduler.csproj", "{6D507659-C644-462A-B605-0342D92051BA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "system-status", "system-status\src\system-status.csproj", "{DAB76B7E-57B8-45BC-A12E-F72797107060}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -119,6 +127,22 @@ Global
 		{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54F9E25D-B0AA-4CB9-B08F-3A78EFDC1FA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96412F26-6713-4895-A68B-3805B4077444}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96412F26-6713-4895-A68B-3805B4077444}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96412F26-6713-4895-A68B-3805B4077444}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96412F26-6713-4895-A68B-3805B4077444}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65AD788B-D452-48D4-8764-7D0173D9561D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65AD788B-D452-48D4-8764-7D0173D9561D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65AD788B-D452-48D4-8764-7D0173D9561D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65AD788B-D452-48D4-8764-7D0173D9561D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D507659-C644-462A-B605-0342D92051BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D507659-C644-462A-B605-0342D92051BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D507659-C644-462A-B605-0342D92051BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D507659-C644-462A-B605-0342D92051BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAB76B7E-57B8-45BC-A12E-F72797107060}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAB76B7E-57B8-45BC-A12E-F72797107060}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAB76B7E-57B8-45BC-A12E-F72797107060}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAB76B7E-57B8-45BC-A12E-F72797107060}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add a cancel callback backend service. Uses case id from get most recent case, to ensure the callback belongs to the user.

I've included rsbc-dmf.sln. It is a solution with all the projects added. I used it to check references on all projects. In theory, it could also be used to run multiple projects from on VS instead of 3-4, and in my head would perform better.