### PR TITLE
DFTDP-86 uploaded document status

### DIFF
--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Dynamics/Mapper/DocumentMapper.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Dynamics/Mapper/DocumentMapper.cs
@@ -75,8 +75,9 @@ namespace Rsbc.Dmf.CaseManagement.Dynamics
         {
             var statusMap = new Dictionary<int, string>()
             {
+                // TODO update to use shared-utils SubmittalStatus.cs
                 { 100000000, "Open-Required"  },
-                { 100000001, "Received" }, 
+                { 100000001, "Received" }, // Accept
                 { 100000003, "Reviewed" },
                 { 100000004, "Reject" },
                 { 100000008, "Sent" },

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/CaseManager.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement/Manager/CaseManager.cs
@@ -206,6 +206,8 @@ namespace Rsbc.Dmf.CaseManagement
         public string ErrorMessage { get; set; }
     }
 
+    [Obsolete("use shared-utils SubmittalStatus.cs")]
+
     public enum submittalStatusOptionSet
     {
         Accept = 100000001,

--- a/driver-portal/src/AutoMapper.cs
+++ b/driver-portal/src/AutoMapper.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using EnumsNET;
 using Google.Protobuf.WellKnownTypes;
+using Pssg.SharedUtils;
 using Rsbc.Dmf.CaseManagement.Service;
 using System.Linq.Expressions;
 

--- a/driver-portal/src/Model/DocumentFactory.cs
+++ b/driver-portal/src/Model/DocumentFactory.cs
@@ -1,4 +1,6 @@
-﻿using Google.Protobuf.WellKnownTypes;
+﻿using EnumsNET;
+using Google.Protobuf.WellKnownTypes;
+using Pssg.SharedUtils;
 using Rsbc.Dmf.CaseManagement.Service;
 
 namespace Rsbc.Dmf.DriverPortal.Api
@@ -39,7 +41,7 @@ namespace Rsbc.Dmf.DriverPortal.Api
                 ValidationPrevious = string.Empty,
                 ImportId = string.Empty,
                 OriginatingNumber = string.Empty,
-                SubmittalStatus = "Sent",
+                SubmittalStatus = SubmittalStatus.Uploaded.AsString(),
             };
         }
     }

--- a/driver-portal/src/Tests/Unit/AutoMapperTests.cs
+++ b/driver-portal/src/Tests/Unit/AutoMapperTests.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using EnumsNET;
 using Google.Protobuf.WellKnownTypes;
+using Pssg.SharedUtils;
 using Rsbc.Dmf.CaseManagement.Service;
 using Rsbc.Dmf.DriverPortal.Api;
 using System;

--- a/driver-portal/src/driver-portal.csproj
+++ b/driver-portal/src/driver-portal.csproj
@@ -77,6 +77,7 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\..\cms-adapter\src\Rsbc.Dmf.CaseManagement.Client\Rsbc.Dmf.CaseManagement.Client.csproj" />
 	  <ProjectReference Include="..\..\document-storage-adapter\src\Pssg.DocumentStorageAdapter.Client\Pssg.DocumentStorageAdapter.Client.csproj" />
+	  <ProjectReference Include="..\..\shared-utils\SharedUtils.csproj" />
 	</ItemGroup>
 
 	<Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">

--- a/driver-portal/src/driver-portal.sln
+++ b/driver-portal/src/driver-portal.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\..\.github\workflows\cd-driver-portal-ui.yml = ..\..\.github\workflows\cd-driver-portal-ui.yml
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedUtils", "..\..\shared-utils\SharedUtils.csproj", "{EBF21CF9-7758-467A-A2BD-B044E804D106}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{2E6D1328-ABE5-42AE-AFE1-37D09269F831}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E6D1328-ABE5-42AE-AFE1-37D09269F831}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E6D1328-ABE5-42AE-AFE1-37D09269F831}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBF21CF9-7758-467A-A2BD-B044E804D106}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBF21CF9-7758-467A-A2BD-B044E804D106}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBF21CF9-7758-467A-A2BD-B044E804D106}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBF21CF9-7758-467A-A2BD-B044E804D106}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/shared-utils/Model/Enum/SubmittalStatus.cs
+++ b/shared-utils/Model/Enum/SubmittalStatus.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace Rsbc.Dmf.DriverPortal.Api
+namespace Pssg.SharedUtils
 {
     // NOTE this should be in a shared library with cms-adapter, so they can both use this enum
     // after moved, remove Enums.NET package from driver-portal project
@@ -27,7 +27,7 @@ namespace Rsbc.Dmf.DriverPortal.Api
         [Description("Carry Forward")]
         CarryForward = 100000006,
 
-        [Description("Received")]
+        [Description("Received")]   // Accept
         Received = 100000001,
 
         [Description("Reject")]


### PR DESCRIPTION
Not tested since I was unable to authenticate. The change is simple enough that I am comfortable merging this anyways. I moved SubmittalStatus enum to shared-utils project, so we can reuse the enum in all solutions.