### PR TITLE
cms-adapter build fix - comment out shared-utils

### DIFF
--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Tests/Rsbc.Dmf.CaseManagement.Tests.csproj
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Tests/Rsbc.Dmf.CaseManagement.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\shared-utils\SharedUtils.csproj" />
+    <!--<ProjectReference Include="..\..\shared-utils\SharedUtils.csproj" />-->
     <ProjectReference Include="..\Rsbc.Dmf.CaseManagement.Service\Rsbc.Dmf.CaseManagement.Service.csproj" />
     <ProjectReference Include="..\Rsbc.Dmf.CaseManagement\Rsbc.Dmf.CaseManagement.csproj" />
   </ItemGroup>

--- a/cms-adapter/src/Rsbc.Dmf.CaseManagement.Tests/Unit/AutoMapperTests.cs
+++ b/cms-adapter/src/Rsbc.Dmf.CaseManagement.Tests/Unit/AutoMapperTests.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using Google.Protobuf.Collections;
 using Rsbc.Dmf.Dynamics.Microsoft.Dynamics.CRM;
-using SharedUtils;
+//using SharedUtils;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -158,7 +158,8 @@ namespace Rsbc.Dmf.CaseManagement.Tests.Unit
             callback.Assignee = "Assignee";
             callback.CallStatus = CallbackCallStatus.Open;
             callback.CaseId = Guid.NewGuid().ToString();
-            callback.Origin = (int)UserCode.Portal;
+            //callback.Origin = (int)UserCode.Portal;
+            callback.Origin = 100000005;
             callback.Phone = "Phone";
             callback.Priority = CallbackPriority.Low;
             callback.PreferredTime = PreferredTime.Morning;


### PR DESCRIPTION
There is an underlying issue with relative filepaths that requires a longer fix before we can use shared-utils in cms-adapter. Until then, I just commented it out