### PR TITLE
DEV add logs to trace error

### DIFF
--- a/medical-practitioner-portal/src/app/app.component.ts
+++ b/medical-practitioner-portal/src/app/app.component.ts
@@ -41,22 +41,27 @@ export class AppComponent {
 
   public async ngOnInit(): Promise<void> {
     try {
+      console.info('AppComponent initializing...');
       //attempt to log in
       this.authService.isLoggedIn().subscribe((isLoggedIn) => {
+        console.info('Are you logged in?', isLoggedIn);
         if (!isLoggedIn) {
+          console.info('Redirect to login page');
           this.authService.login({
             idpHint: IdentityProvider.BCSC,
             // TODO add medical-portal scope and move this to api/Config
             scope: 'openid profile email',
           });
-        }
-        if (isLoggedIn) {
+        } else {
+          // for spinner status, this will likely change when the keycloak auth lifecycle events are refactored
           this.isLoading = false;
         }
       });
     } catch (e) {
       console.error(e);
       throw e;
+    } finally {
+      console.info('AppComponent initialization completed.');
     }
   }
 

--- a/medical-practitioner-portal/src/app/modules/keycloak/keycloak-init.service.ts
+++ b/medical-practitioner-portal/src/app/modules/keycloak/keycloak-init.service.ts
@@ -17,20 +17,30 @@ export class KeycloakInitService {
   ) {}
 
   public async load(): Promise<void> {
+    console.info('Keycloak initializing...');
     const authenticated = await this.keycloakService.init(
       this.getKeycloakOptions()
     );
+    console.info('Keycloak authenticated:', authenticated);
 
     this.keycloakService.getKeycloakInstance().onTokenExpired = (): void => {
+      console.info('Keycloak token expired, updating token');
       this.keycloakService
         .updateToken()
-        .catch(() => this.router.navigateByUrl(AuthRoutes.MODULE_PATH));
+        .catch((reason) => {
+          console.error('Keycloak failed to update token', reason);
+          this.router.navigateByUrl(AuthRoutes.MODULE_PATH)
+        });
     };
 
-    if (authenticated) {
-      // Force refresh to begin expiry timer
-      await this.keycloakService.updateToken(-1);
-    }
+    // Code from POC that I don't fully understand. It was working but at some point either stopped working or became red herring
+    // Gonna try disabling this and see if the DEV javascript error changes
+    // if (authenticated) {
+    //   // Force refresh to begin expiry timer
+    //   await this.keycloakService.updateToken(-1);
+    // }
+
+    console.info('Keycloak initialization completed.');
   }
 
   private getKeycloakOptions(): KeycloakOptions {


### PR DESCRIPTION
added console.info logs and commented out keycloak expire token code. I suspect the keycloak expire token code was a work-around for the older version of keycloak and I didn't see any code examples that used this in conjunction with keycloak.init