### PR TITLE
BUG - pipeline build shared library

### DIFF
--- a/medical-portal/src/UI/Dockerfile
+++ b/medical-portal/src/UI/Dockerfile
@@ -6,6 +6,7 @@ COPY ./medical-portal/src/UI/ ./medical-portal/src/UI
 WORKDIR /app/shared-portal-ui
 
 RUN npm install
+RUN npm run build
 
 WORKDIR /app/medical-portal/src/UI
 


### PR DESCRIPTION
The medical portal UI is failing because it is not getting the latest changes. This will build the shared library first before building the medical portal UI project, so it installs the latest version of shared library. If this works, I will add the same change to driver and partner portals.