### PR TITLE
Get Assistance links are using RouterLink component

### DIFF
--- a/shared-portal-ui/projects/core-ui/src/lib/letters-to-driver/letters-to-driver.component.html
+++ b/shared-portal-ui/projects/core-ui/src/lib/letters-to-driver/letters-to-driver.component.html
@@ -13,7 +13,7 @@
       </p>
       @if(portal===PortalsEnum.DriverPortal){
         <p>
-          See <a href="/getAssistance">Get Assistance</a>.
+          See <a routerLink="/getAssistance">Get Assistance</a>.
         </p>
       }
     </div>

--- a/shared-portal-ui/projects/core-ui/src/lib/letters-to-driver/letters-to-driver.component.ts
+++ b/shared-portal-ui/projects/core-ui/src/lib/letters-to-driver/letters-to-driver.component.ts
@@ -10,6 +10,7 @@ import {LetterTopicComponent} from '../case-definitions/letter-topic/letter-topi
 import { PortalsEnum, SubmittalStatusEnum } from '../app.model';
 import { Document } from '../api';
 import { SharedQuickLinksComponent } from '../quick-links/quick-links.component';
+import { RouterLink } from '@angular/router';
 
 @Component({
     selector: 'app-shared-letters-to-driver',
@@ -31,7 +32,8 @@ import { SharedQuickLinksComponent } from '../quick-links/quick-links.component'
         CaseTypeComponent,
         LetterTopicComponent,
         DatePipe,
-        SharedQuickLinksComponent
+        SharedQuickLinksComponent,
+        RouterLink
     ],
 })
 export class SharedLettersToDriverComponent implements OnInit {

--- a/shared-portal-ui/projects/core-ui/src/lib/submission-history/submission-history.component.html
+++ b/shared-portal-ui/projects/core-ui/src/lib/submission-history/submission-history.component.html
@@ -18,7 +18,7 @@
         </p>
         @if(portal===PortalsEnum.DriverPortal){
           <p>
-            See <a href="/getAssistance">Get Assistance</a>.
+            See <a routerLink="/getAssistance">Get Assistance</a>.
           </p>
         }
       </div>

--- a/shared-portal-ui/projects/core-ui/src/lib/submission-history/submission-history.component.ts
+++ b/shared-portal-ui/projects/core-ui/src/lib/submission-history/submission-history.component.ts
@@ -9,6 +9,7 @@ import { SubmissionStatusComponent } from '../case-definitions/submission-status
 import { SubmissionTypeComponent } from '../case-definitions/submission-type/submission-type.component';
 import { PortalsEnum, SubmittalStatusEnum } from '../app.model';
 import { SharedQuickLinksComponent } from "../quick-links/quick-links.component";
+import { RouterLink } from '@angular/router';
 
 @Component({
     selector: 'app-shared-submission-history',
@@ -30,7 +31,8 @@ import { SharedQuickLinksComponent } from "../quick-links/quick-links.component"
     SubmissionTypeComponent,
     SubmissionStatusComponent,
     DatePipe,
-    SharedQuickLinksComponent
+    SharedQuickLinksComponent,
+    RouterLink
 ],
 })
 export class SharedSubmissionHistoryComponent implements OnInit {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

    Get Assistance links are using RouterLink component

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Manual Testing

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No


